### PR TITLE
0.1.1 Release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # Change log
 
 ## master (unreleased)
+
+## 0.1.1 (2016-05-17)
+
 ### New features
 * Add ability to configure units of measurements
 * Add support of `line_3d`, `bar3DChart`, `pie3DChart` charts

--- a/lib/ooxml_parser/version.rb
+++ b/lib/ooxml_parser/version.rb
@@ -1,6 +1,6 @@
 module OoxmlParser
   # This module holds the RuboCop version information.
   module Version
-    STRING = '0.1.0'.freeze
+    STRING = '0.1.1'.freeze
   end
 end

--- a/ooxml_parser.gemspec
+++ b/ooxml_parser.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rubyzip', '~> 1.1')
   s.add_runtime_dependency('xml-simple', '~> 1.1')
   s.homepage = 'http://rubygems.org/gems/ooxml_parser'
-  s.license = 'AGPL'
+  s.license = 'AGPL-3.0'
 end


### PR DESCRIPTION
## 0.1.1 (2016-05-17)

### New features
* Add ability to configure units of measurements
* Add support of `line_3d`, `bar3DChart`, `pie3DChart` charts
* Add parsing text direction in table cell
* Refactor parsing page size of document
* Refactor parsing page margins of docx
* Refactor parsing columns data of docx
* Some minor RuboCop refactor
* Add parsing `fldSimple` inside hyperlinks
* Add support of `wp14:pctPosHOffset` and `wp14:pctPosVOffset`
* Add support of parsing `w:noBreakHyphen`, `w:tab` in PargraphRun
* Add support of Table Row Properties - Height
* Add variable to store original file path in all parsers

### Fixes
* Fix parsing shape in paragraph run