### PR TITLE
Remove usage of Linux `file` command in favor of `ruby-filemagick` 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ rvm:
 - 2.2
 - 2.1
 - 2.0
+addons:
+  apt_packages:
+    libmagic-dev
 script:
   - bundle exec parallel_rspec spec

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 * Add parsing math formula run properties (and redone some math model for it)
 * Add parsing math formula argument size property
 * Add a whole lot new properties to parse in charts
+* Remove usage of Linux `file` command in favor of `ruby-filemagick` gem. Better cross-platform support
 
 ### Fixes
 * Fix misplaced `dxa` and `emu` units of measurements and also fix calculation `dxa` unit

--- a/lib/ooxml_parser/common_parser/common_data/ooxml_document_object.rb
+++ b/lib/ooxml_parser/common_parser/common_data/ooxml_document_object.rb
@@ -1,3 +1,4 @@
+require 'filemagic'
 require 'securerandom'
 require 'nokogiri'
 require 'xmlsimple'
@@ -26,11 +27,11 @@ module OoxmlParser
       # @param path_to_file [String] file
       # @return [True, False] Check if file is protected by password on open
       def encrypted_file?(path_to_file)
-        file_result = `file "#{path_to_file}"`
+        file_result = FileMagic.new(:mime).file(path_to_file)
         # Support of Encrtypted status in `file` util was introduced in file v5.20
         # but LTS version of ubuntu before 16.04 uses older `file` and it return `Composite Document`
         # https://github.com/file/file/blob/master/ChangeLog#L217
-        if file_result.include?('Encrypted') || file_result.include?('Composite Document File V2 Document, No summary info')
+        if file_result.include?('encrypted') || file_result.include?('Composite Document File V2 Document, No summary info')
           warn("File #{path_to_file} is encrypted. Can't parse it")
           return true
         end

--- a/ooxml_parser.gemspec
+++ b/ooxml_parser.gemspec
@@ -9,9 +9,10 @@ Gem::Specification.new do |s|
   s.summary = 'OoxmlParser Gem'
   s.description = 'Parse OOXML files (docx, xlsx, pptx)'
   s.email = ['shockwavenn@gmail.com', 'rzagudaev@gmail.com']
-  s.files = `git ls-files lib LICENSE.txt README.md `.split($RS)
+  s.files = `git ls-files lib LICENSE.txt README.md`.split($RS)
   s.add_runtime_dependency('nokogiri', '~> 1.6')
   s.add_runtime_dependency('rubyzip', '~> 1.1')
+  s.add_runtime_dependency('ruby-filemagic')
   s.add_runtime_dependency('xml-simple', '~> 1.1')
   s.homepage = 'http://rubygems.org/gems/ooxml_parser'
   s.license = 'AGPL-3.0'


### PR DESCRIPTION
Better cross-platform support, first step of support this gem on Windows 