### PR TITLE
Change method to read file for working on windows

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 ### New features
+* Fully support of Windows platform
 * Add parsing of Shape Adjust Values List
 * Add parsing Relative Sizes of shape
 * Add parsing math formula run properties (and redone some math model for it)

--- a/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/picture/docx_blip/file_reference.rb
+++ b/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/picture/docx_blip/file_reference.rb
@@ -17,7 +17,7 @@ module OoxmlParser
       return file_ref if file_ref.path == 'NULL'
       full_path_to_file = OOXMLDocumentObject.path_to_folder + OOXMLDocumentObject.root_subfolder + file_ref.path
       if File.exist?(full_path_to_file)
-        file_ref.content = File.read(full_path_to_file)
+        file_ref.content = IO.binread(full_path_to_file)
       else
         warn "Couldn't find #{full_path_to_file} file on filesystem. Possible problem in original document"
       end


### PR DESCRIPTION
Old variant I presume end reading on EOF symbol,
which may be read in binary file in any place.
Now fully support Windows platform.