### PR TITLE
Revert "Use codeclimate instead of codecov for test coverage"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ rvm:
 - 2.1
 - 2.0
 addons:
-  code_climate:
-    repo_token: 0deb9b6dcbe43d8dc0af250919d9871f289e1bb90a050e5e22d5efd5c0a559e0
   apt_packages:
     libmagic-dev
 script:
-  - CODECLIMATE_REPO_TOKEN=0deb9b6dcbe43d8dc0af250919d9871f289e1bb90a050e5e22d5efd5c0a559e0 bundle exec parallel_rspec spec
+  - bundle exec parallel_rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'codeclimate-test-reporter', group: :test, require: nil
+gem 'codecov', require: false, group: :test
 gem 'parallel_tests', group: [:development, :test]
 gem 'rake', '~> 10.1'
 gem 'rspec', '~> 3.4.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
 require 'ooxml_parser'


### PR DESCRIPTION
Reverts ONLYOFFICE/ooxml_parser#276,

CodeClimate doesn't support parallel specs
See https://codeclimate.com/repos/573b455f6e1c6b58d0007202/coverage_setup
```
Single payload:
We currently only support a single test coverage payload per commit. If you run your tests in multiple steps, or via parallel tests, Code Climate will only process the first payload that we receive. If you are using a CI, be sure to check if you are running your tests in a parallel mode.
```