### PR TITLE
Temporary install specific version of nokogiri

### DIFF
--- a/ooxml_parser.gemspec
+++ b/ooxml_parser.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = 'Parse OOXML files (docx, xlsx, pptx)'
   s.email = ['shockwavenn@gmail.com', 'rzagudaev@gmail.com']
   s.files = `git ls-files lib LICENSE.txt README.md`.split($RS)
-  s.add_runtime_dependency('nokogiri', '~> 1.6')
+  s.add_runtime_dependency('nokogiri', '1.6.8')
   s.add_runtime_dependency('rubyzip', '~> 1.1')
   s.add_runtime_dependency('ruby-filemagic')
   s.add_runtime_dependency('xml-simple', '~> 1.1')


### PR DESCRIPTION
Latest have problem with
```
checking whether to enable maintainer-specific portions of Makefiles... yes
checking build system type... mkdir: cannot create directory '/tmp/cg398-20130':
No such file or directory
mkdir: cannot create directory '/tmp/cg-398': No such file or directory
config.guess: cannot create a temporary directory in /tmp
configure: error: cannot guess build type; you must specify one
```
Need to investigate