### PR TITLE
Fix rspec warning

### DIFF
--- a/spec/presentation/slide/background/fill/background_image_fill_spec.rb
+++ b/spec/presentation/slide/background/fill/background_image_fill_spec.rb
@@ -14,6 +14,6 @@ describe 'My behaviour' do
   end
 
   it 'image_embeded_by_link' do
-    expect { OoxmlParser::PptxParser.parse_pptx('spec/presentation/slide/background/fill/image/image_no_embedded.pptx') }.not_to raise_error(LoadError)
+    expect { OoxmlParser::PptxParser.parse_pptx('spec/presentation/slide/background/fill/image/image_no_embedded.pptx') }.not_to raise_error
   end
 end


### PR DESCRIPTION
```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError)
```