### PR TITLE
install libmagic before bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ _ooxml_parser_ is a Ooxml files (docx, xlsx, pptx) parser written in Ruby.
 
 ## Installation
 
+    $ brew install libmagic # MacOSX
+    $ sudo apt-get install libmagic-dev # Linux
     $ gem install ooxml_parser
     
 ## Usage


### PR DESCRIPTION
:) Spoiler: https://stackoverflow.com/questions/15577171/missing-library-while-installing-ruby-filemagic-gem-on-linux
On `bundle install` error raised:
```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/andrew.zelenets/.rvm/gems/ruby-2.3.0@vo-vi/gems/ruby-filemagic-0.7.2/ext/filemagic
/Users/andrew.zelenets/.rvm/rubies/ruby-2.3.0/bin/ruby -r ./siteconf20170811-24091-9mu6qk.rb extconf.rb
checking for main() in -lgnurx... no
checking for magic_open() in -lmagic... no
*** ERROR: missing required library to compile this module
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/Users/andrew.zelenets/.rvm/rubies/ruby-2.3.0/bin/$(RUBY_BASE_NAME)
        --with-magic-dir
        --without-magic-dir
        --with-magic-include
        --without-magic-include=${magic-dir}/include
        --with-magic-lib
        --without-magic-lib=${magic-dir}/lib
        --with-gnurx-dir
        --without-gnurx-dir
        --with-gnurx-include
        --without-gnurx-include=${gnurx-dir}/include
        --with-gnurx-lib
        --without-gnurx-lib=${gnurx-dir}/lib
        --with-gnurxlib
        --without-gnurxlib
        --with-magiclib
        --without-magiclib

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /Users/andrew.zelenets/.rvm/gems/ruby-2.3.0@vo-vi/extensions/x86_64-darwin-16/2.3.0/ruby-filemagic-0.7.2/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /Users/andrew.zelenets/.rvm/gems/ruby-2.3.0@vo-vi/gems/ruby-filemagic-0.7.2 for inspection.
Results logged to /Users/andrew.zelenets/.rvm/gems/ruby-2.3.0@vo-vi/extensions/x86_64-darwin-16/2.3.0/ruby-filemagic-0.7.2/gem_make.out

An error occurred while installing ruby-filemagic (0.7.2), and Bundler cannot continue.
Make sure that `gem install ruby-filemagic -v '0.7.2'` succeeds before bundling.

In Gemfile:
  ooxml_parser was resolved to 0.2.0, which depends on
    ruby-filemagic
```