### PR TITLE
Fix detecting password protected files on old `FileMagic`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@
 
 ### Fixes
 * Fix `uninitialized constant OoxmlParser::Inserted::DateTime` while parsing `Inserted#date`
+* Fix detecting password protected files on old `FileMagic`
 
 ## 0.2.0 (2017-03-25)
 ### New features

--- a/lib/ooxml_parser/common_parser/common_data/ooxml_document_object.rb
+++ b/lib/ooxml_parser/common_parser/common_data/ooxml_document_object.rb
@@ -42,7 +42,9 @@ module OoxmlParser
         # Support of Encrtypted status in `file` util was introduced in file v5.20
         # but LTS version of ubuntu before 16.04 uses older `file` and it return `Composite Document`
         # https://github.com/file/file/blob/master/ChangeLog#L217
-        if file_result.include?('encrypted') || file_result.include?('Composite Document File V2 Document, No summary info')
+        if file_result.include?('encrypted') ||
+           file_result.include?('Composite Document File V2 Document, No summary info') ||
+           file_result.include?('application/CDFV2-corrupt')
           warn("File #{path_to_file} is encrypted. Can't parse it")
           return true
         end


### PR DESCRIPTION
For some reason it show now `application/CDFV2-corrupt`
Maybe somehow related with travis ecosystem and `filemagic` downgrade
On file-5.29 `file` output show correct MIME
But on `file-5.15` it show corrupted