### PR TITLE
Revert "Deprecation warning for `DocxParagraph#page_break`"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,6 @@
 ### Refactor
 * Store `sdt` as `DocxParagraph#character_styles_array` element
 * Deprecation warning for `DocxParagraph#frame_properties`
-* Deprecation warning for `DocxParagraph#page_break`
 * Remove unused and probably not real `DocxParagraph#kinoku`
 
 ## 0.4.1 (2018-03-01)

--- a/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_properties.rb
+++ b/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_properties.rb
@@ -14,8 +14,6 @@ module OoxmlParser
     attr_accessor :run_properties
     # @return [Borders] borders of paragraph
     attr_accessor :paragraph_borders
-    # @return [Boolean] is before paragraph page break
-    attr_reader :page_break_before
     # @return [True, False] Specifies that the paragraph
     # (or at least part of it) should be rendered on
     # the same page as the next paragraph when possible
@@ -81,8 +79,6 @@ module OoxmlParser
           @indent = Indents.new(parent: self).parse(node_child)
         when 'rPr'
           @run_properties = RunProperties.new(parent: self).parse(node_child)
-        when 'pageBreakBefore'
-          @page_break_before = option_enabled?(node_child)
         when 'pBdr'
           @paragraph_borders = ParagraphBorders.new(parent: self).parse(node_child)
         when 'keepNext'

--- a/lib/ooxml_parser/docx_parser/docx_data/document_structure/docx_paragraph.rb
+++ b/lib/ooxml_parser/docx_parser/docx_data/document_structure/docx_paragraph.rb
@@ -13,7 +13,7 @@ module OoxmlParser
   class DocxParagraph < OOXMLDocumentObject
     include DocxParagraphHelper
     attr_accessor :number, :bookmark_start, :bookmark_end, :align, :spacing, :background_color, :ind, :numbering,
-                  :character_style_array, :horizontal_line, :borders, :keep_lines,
+                  :character_style_array, :horizontal_line, :page_break, :borders, :keep_lines,
                   :contextual_spacing, :sector_properties, :page_numbering, :section_break, :style, :keep_next,
                   :orphan_control
     # @return [Hyperlink] hyperlink in paragraph
@@ -40,6 +40,7 @@ module OoxmlParser
       @ind = Indents.new
       @character_style_array = []
       @horizontal_line = false
+      @page_break = false
       @borders = Borders.new
       @keep_lines = false
       @contextual_spacing = false
@@ -179,6 +180,8 @@ module OoxmlParser
     def parse_paragraph_style(node, default_char_style = DocxParagraphRun.new)
       node.xpath('*').each do |node_child|
         case node_child.name
+        when 'pageBreakBefore'
+          @page_break = true if node_child.attribute('val').nil? || node_child.attribute('val').value != 'false'
         when 'pBdr'
           @borders = ParagraphBorders.new(parent: self).parse(node_child)
         when 'keepLines'
@@ -262,11 +265,5 @@ module OoxmlParser
       paragraph_properties.frame_properties
     end
     deprecate :frame_properties, 'paragraph_properties.frame_properties', 2020, 1
-
-    # @return [Boolean] is page break before
-    def page_break
-      paragraph_properties.page_break_before
-    end
-    deprecate :page_break, 'paragraph_properties.page_break_before', 2020, 1
   end
 end


### PR DESCRIPTION
Reverts ONLYOFFICE/ooxml_parser#472.

Broke test in https://github.com/ONLYOFFICE/doc-builder-testing/blob/d1b9271d41aee688e7ae4b6abe3d82c3be761ede/spec/docx/smoke/api_paragraph_properties_spec.rb#L94

Need to implement parsing of `pStyle`