### PR TITLE
Unit of PageMargins in xlsx are inches

### DIFF
--- a/lib/ooxml_parser/docx_parser/docx_data/document_structure/page_properties/page_margins.rb
+++ b/lib/ooxml_parser/docx_parser/docx_data/document_structure/page_properties/page_margins.rb
@@ -17,23 +17,23 @@ module OoxmlParser
     # Parse BordersProperties
     # @param [Nokogiri::XML:Element] node with PageMargins
     # @return [PageMargins] value of PageMargins
-    def parse(node)
+    def parse(node, unit = :dxa)
       node.attributes.each do |key, value|
         case key
         when 'top'
-          @top = OoxmlSize.new(value.value.to_f)
+          @top = OoxmlSize.new(value.value.to_f, unit)
         when 'left'
-          @left = OoxmlSize.new(value.value.to_f)
+          @left = OoxmlSize.new(value.value.to_f, unit)
         when 'right'
-          @right = OoxmlSize.new(value.value.to_f)
+          @right = OoxmlSize.new(value.value.to_f, unit)
         when 'bottom'
-          @bottom = OoxmlSize.new(value.value.to_f)
+          @bottom = OoxmlSize.new(value.value.to_f, unit)
         when 'header'
-          @header = OoxmlSize.new(value.value.to_f)
+          @header = OoxmlSize.new(value.value.to_f, unit)
         when 'footer'
-          @footer = OoxmlSize.new(value.value.to_f)
+          @footer = OoxmlSize.new(value.value.to_f, unit)
         when 'gutter'
-          @gutter = OoxmlSize.new(value.value.to_f)
+          @gutter = OoxmlSize.new(value.value.to_f, unit)
         end
       end
       self

--- a/lib/ooxml_parser/xlsx_parser/xlsx_data/view_model/workbook/worksheet.rb
+++ b/lib/ooxml_parser/xlsx_parser/xlsx_data/view_model/workbook/worksheet.rb
@@ -110,7 +110,7 @@ module OoxmlParser
         when 'oleObjects'
           @ole_objects = OleObjects.new(parent: self).parse(worksheet_node_child)
         when 'pageMargins'
-          @page_margins = PageMargins.new(parent: self).parse(worksheet_node_child)
+          @page_margins = PageMargins.new(parent: self).parse(worksheet_node_child, :inch)
         when 'pageSetup'
           @page_setup = PageSetup.new(parent: self).parse(worksheet_node_child)
         when 'extLst'

--- a/spec/workbook/worksheet/page_margins_spec.rb
+++ b/spec/workbook/worksheet/page_margins_spec.rb
@@ -7,6 +7,10 @@ describe OoxmlParser::PageMargins do
     expect(xlsx.worksheets.first.page_margins.top.value).to eq(0.75196850393700787)
   end
 
+  it 'PageMargins#top is in inches' do
+    expect(xlsx.worksheets.first.page_margins.top.unit).to eq(:inch)
+  end
+
   it 'PageMargins#bottom' do
     expect(xlsx.worksheets.first.page_margins.bottom.value).to eq(0.75196850393700787)
   end


### PR DESCRIPTION
According to:
https://msdn.microsoft.com/en-us/library/documentformat.openxml.spreadsheet.pagemargins.aspx