### PR TITLE
Remove tests on 2.1 and 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ rvm:
   - 2.5.1
   - 2.4.4
   - 2.3.7
-  - 2.2.10
-  - 2.1.10
 
 before_install:
   - gem update --system


### PR DESCRIPTION
`gem update --system` cause error on those version,
since they not supported by rubygems 3.0
Don't see a reason to continue test on them