### PR TITLE
Allow failures on ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ rvm:
   - 2.5.1
   - 2.4.4
   - 2.3.7
-
+matrix:
+  allow_failures:
+  - rvm: ruby-head
 before_install:
   - gem update --system
 install:


### PR DESCRIPTION
Currently it's failing because of:
https://github.com/bundler/bundler/pull/7248