### PR TITLE
Redone parsing TextBox

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -68,6 +68,7 @@
 * Redone parsing of `DocxStructure#comments`
 * Change `DocxStructure#parse_default_style` to instance method
 * Change `DocxStructure#parse_paragraph_style_xml` to instance method
+* Redone parsing `TextBox`, 
   
 ### Fixes
 * Fix crash on empty coordinates list of chart

--- a/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/shape/shape_properties/docx_shape_properties.rb
+++ b/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/shape/shape_properties/docx_shape_properties.rb
@@ -32,7 +32,7 @@ module OoxmlParser
         when 'prstGeom'
           @preset_geometry = PresetGeometry.new(parent: self).parse(node_child)
         when 'txbx'
-          @text_box = TextBox.parse_list(node_child)
+          @text_box = TextBox.new(parent: self).parse(node_child)
         when 'ln'
           @line = DocxShapeLine.new(parent: self).parse(node_child)
         when 'blipFill'

--- a/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/shape/shape_properties/docx_shape_properties/text_box.rb
+++ b/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/shape/shape_properties/docx_shape_properties/text_box.rb
@@ -1,25 +1,22 @@
-# Class for working with TextBox (w:txbxContent)
+require_relative 'text_box/text_box_content'
+
 module OoxmlParser
-  class TextBox
-    # Parse TextBox List
-    # @param [Nokogiri::XML:Node] node with TextBox
-    # @return [Array] array of elements
-    def self.parse_list(node, parent: nil)
-      elements = []
-      text_box_content_node = node.xpath('w:txbxContent').first
-      unless text_box_content_node.nil?
-        text_box_content_node.xpath('*').each_with_index do |textbox_element, i|
-          case textbox_element.name
-          when 'p'
-            DocumentStructure.default_paragraph_style = DocxParagraph.new
-            DocumentStructure.default_paragraph_style.spacing = Spacing.new(0, 0.35, 1.15, :multiple)
-            elements << DocumentStructure.default_paragraph_style.dup.parse(textbox_element, i, parent: parent)
-          when 'tbl'
-            elements << Table.new(parent: parent).parse(textbox_element, i)
-          end
+  # Class for working with TextBox (v:textbox)
+  class TextBox < OOXMLDocumentObject
+    # @return [TextBoxContent] text box content
+    attr_reader :text_box_content
+
+    # Parse TextBox object
+    # @param node [Nokogiri::XML:Element] node to parse
+    # @return [TextBox] result of parsing
+    def parse(node)
+      node.xpath('*').each do |node_child|
+        case node_child.name
+        when 'txbxContent'
+          @text_box_content = TextBoxContent.new(parent: self).parse(node_child)
         end
       end
-      elements
+      self
     end
   end
 end

--- a/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/shape/shape_properties/docx_shape_properties/text_box/text_box_content.rb
+++ b/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/shape/shape_properties/docx_shape_properties/text_box/text_box_content.rb
@@ -1,0 +1,35 @@
+module OoxmlParser
+  # Class for working with TextBoxContent (w:txbxContent)
+  class TextBoxContent < OOXMLDocumentObject
+    # @return [Array<Paragraphs>] list of paragraphs
+    attr_reader :paragraphs
+    # @return [Array<Table>] list of tables
+    attr_reader :tables
+
+    def initialize(parent: nil)
+      @paragraphs = []
+      @tables = []
+      @parent = parent
+    end
+
+    # Parse TextBoxContent object
+    # @param node [Nokogiri::XML:Element] node to parse
+    # @return [TextBoxContent] result of parsing
+    def parse(node)
+      node.xpath('*').each do |node_child|
+        case node_child.name
+        when 'p'
+          @paragraphs << Paragraph.new(parent: self).parse(node_child)
+        when 'tbl'
+          @tables << Table.new(parent: self).parse(node_child)
+        end
+      end
+      self
+    end
+
+    # @return [Array] list of all elements in text box control
+    def elements
+      [@paragraphs, @tables].flatten
+    end
+  end
+end

--- a/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/shape/shape_properties/docx_shape_properties/text_box/text_box_content.rb
+++ b/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/shape/shape_properties/docx_shape_properties/text_box/text_box_content.rb
@@ -1,14 +1,11 @@
 module OoxmlParser
   # Class for working with TextBoxContent (w:txbxContent)
   class TextBoxContent < OOXMLDocumentObject
-    # @return [Array<Paragraphs>] list of paragraphs
-    attr_reader :paragraphs
-    # @return [Array<Table>] list of tables
-    attr_reader :tables
+    # @return [Array] list of elements
+    attr_reader :elements
 
     def initialize(parent: nil)
-      @paragraphs = []
-      @tables = []
+      @elements = []
       @parent = parent
     end
 
@@ -19,17 +16,12 @@ module OoxmlParser
       node.xpath('*').each do |node_child|
         case node_child.name
         when 'p'
-          @paragraphs << Paragraph.new(parent: self).parse(node_child)
+          @elements << Paragraph.new(parent: self).parse(node_child)
         when 'tbl'
-          @tables << Table.new(parent: self).parse(node_child)
+          @elements << Table.new(parent: self).parse(node_child)
         end
       end
       self
-    end
-
-    # @return [Array] list of all elements in text box control
-    def elements
-      [@paragraphs, @tables].flatten
     end
   end
 end

--- a/lib/ooxml_parser/common_parser/common_data/alternate_content/picture/shape/old_docx_shape.rb
+++ b/lib/ooxml_parser/common_parser/common_data/alternate_content/picture/shape/old_docx_shape.rb
@@ -14,7 +14,7 @@ module OoxmlParser
       node.xpath('*').each do |node_child|
         case node_child.name
         when 'textbox'
-          @text_box = TextBox.parse_list(node_child, parent: self)
+          @text_box = TextBox.new(parent: self).parse(node_child)
         when 'imagedata'
           @file_reference = FileReference.new(parent: self).parse(node_child)
         when 'fill'

--- a/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_properties.rb
+++ b/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_properties.rb
@@ -27,9 +27,11 @@ module OoxmlParser
     attr_accessor :contextual_spacing
     # @return [Symbol] The alignment or justification to be applied to a paragraph
     attr_accessor :justification
+    # @return [NumberingProperties] properties of numbering
+    attr_accessor :numbering_properties
 
-    def initialize(numbering = NumberingProperties.new, parent: nil)
-      @numbering = numbering
+    def initialize(parent: nil)
+      @numbering = NumberingProperties.new(parent: self)
       @spacing = Spacing.new(OoxmlSize.new(0),
                              OoxmlSize.new(0),
                              OoxmlSize.new(1, :centimeter),
@@ -91,6 +93,8 @@ module OoxmlParser
           @justification = value_to_symbol(node_child.attribute('val'))
         when 'contextualSpacing'
           @contextual_spacing = option_enabled?(node_child)
+        when 'numPr'
+          @numbering_properties = NumberingProperties.new(parent: self).parse(node_child)
         end
       end
       self

--- a/lib/ooxml_parser/docx_parser/docx_data/document_structure.rb
+++ b/lib/ooxml_parser/docx_parser/docx_data/document_structure.rb
@@ -63,7 +63,7 @@ module OoxmlParser
         when :docx_paragraph, :simple, :paragraph
           elements
         when :shape
-          elements[0].nonempty_runs.first.alternate_content.office2007_content.data.text_box
+          elements[0].nonempty_runs.first.alternate_content.office2007_content.data.text_box.text_box_content.elements
         else
           raise 'Wrong location(Need One of ":table", ":paragraph", ":shape")'
         end

--- a/lib/ooxml_parser/docx_parser/docx_data/document_structure/docx_paragraph/docx_paragraph_run/shape.rb
+++ b/lib/ooxml_parser/docx_parser/docx_data/document_structure/docx_paragraph/docx_paragraph_run/shape.rb
@@ -3,6 +3,8 @@ module OoxmlParser
   # Class for parsing `shape`, `rect`, `oval` tags
   class Shape < OOXMLDocumentObject
     attr_accessor :type, :properties, :elements
+    # @return [TextBox] text box
+    attr_reader :text_box
 
     def initialize(type = nil,
                    properties = ShapeProperties.new,
@@ -36,10 +38,16 @@ module OoxmlParser
           @properties.position = property.split(':').last
         end
       end
+
+      node.xpath('*').each do |node_child|
+        case node_child.name
+        when 'textbox'
+          @text_box = TextBox.new(parent: self).parse(node_child)
+        end
+      end
       @properties.fill_color = Color.new(parent: self).parse_hex_string(node.attribute('fillcolor').value.to_s.sub('#', '').split(' ').first) unless node.attribute('fillcolor').nil?
       @properties.stroke.weight = node.attribute('strokeweight').value unless node.attribute('strokeweight').nil?
       @properties.stroke.color = Color.new(parent: self).parse_hex_string(node.attribute('strokecolor').value.to_s.sub('#', '').split(' ').first) unless node.attribute('strokecolor').nil?
-      @elements = TextBox.parse_list(node.xpath('v:textbox').first, parent: self) unless node.xpath('v:textbox').first.nil?
       self
     end
   end

--- a/spec/document/elements/paragraph/numbering_spec.rb
+++ b/spec/document/elements/paragraph/numbering_spec.rb
@@ -32,8 +32,11 @@ describe OoxmlParser::Numbering do
 
   it 'numbering_in_shape.docx' do
     docx = OoxmlParser::DocxParser.parse_docx('spec/document/elements/paragraph/numbering/numbering_in_shape.docx')
-    expect(docx.elements[0].nonempty_runs.first.alternate_content.office2007_content
-               .data.text_box.first.numbering.abstruct_numbering
+    expect(docx.elements[0].nonempty_runs.first
+               .alternate_content.office2007_content
+               .data.text_box.text_box_content.elements.first
+               .properties.numbering_properties
+               .abstruct_numbering
                .level_list.first.text.value).to eq('Ø')
   end
 

--- a/spec/document/elements/paragraph/runs/alternate_content/office2007_content/data/text_box_spec.rb
+++ b/spec/document/elements/paragraph/runs/alternate_content/office2007_content/data/text_box_spec.rb
@@ -3,7 +3,12 @@ require 'spec_helper'
 describe 'My behaviour' do
   it 'table_in_text_box' do
     docx = OoxmlParser::DocxParser.parse_docx('spec/document/elements/paragraph/runs/alternate_content/office2007_content/data/text_box/table_in_text_box.docx')
-    expect(docx.elements.first.nonempty_runs.first.alternate_content.office2007_content.data.text_box[1].rows.size).to eq(5)
-    expect(docx.elements.first.nonempty_runs.first.alternate_content.office2007_content.data.text_box[1].rows.first.cells.size).to eq(5)
+    table_rows = docx.elements.first.nonempty_runs
+                     .first.alternate_content
+                     .office2007_content.data
+                     .text_box.text_box_content
+                     .elements[1].rows
+    expect(table_rows.size).to eq(5)
+    expect(table_rows.first.cells.size).to eq(5)
   end
 end

--- a/spec/document/elements/paragraph/runs/paragraph_run_text_spec.rb
+++ b/spec/document/elements/paragraph/runs/paragraph_run_text_spec.rb
@@ -25,7 +25,8 @@ describe 'My behaviour' do
     docx = OoxmlParser::DocxParser.parse_docx('spec/document/elements/paragraph/runs/text/shape_with_text.docx')
     expect(docx.elements.first.nonempty_runs
                .first.alternate_content.office2007_content
-               .data.text_box.first
+               .data.text_box.text_box_content
+               .elements.first
                .character_style_array.first.text)
       .to eq('Lorem ipsum dolor sit amet, consectetur adipiscing elit.'\
              ' Integer consequat faucibus eros, sed mattis tortor consectetur '\
@@ -57,6 +58,9 @@ describe 'My behaviour' do
 
   it 'text_box_list' do
     docx = OoxmlParser::DocxParser.parse_docx('spec/document/elements/paragraph/runs/text/text_box_list.docx')
-    expect(docx.elements[160].character_style_array.first.shape.elements.first.character_style_array.first.text).to include('Guidelines')
+    expect(docx.elements[160].character_style_array
+               .first.shape.text_box.text_box_content
+               .elements.first.character_style_array
+               .first.text).to include('Guidelines')
   end
 end


### PR DESCRIPTION
Old parsing was dirty and unlogical, @text_box store
paragraphs and tables instead of actual TextBox