### PR TITLE
Fix `OoxmlSize#to_s` to output same result on all supported ruby-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Do not raise waring if `FileReference#path` is correct url
 * Fix comparing two child of `OOXMLDocumentObject` with different classes
+* Fix `OoxmlSize#to_s` to output same result on all supported ruby-version
 
 ### Changes
 

--- a/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/drawing_properties/ooxml_size.rb
+++ b/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/drawing_properties/ooxml_size.rb
@@ -40,7 +40,7 @@ module OoxmlParser
     # @return [String] string representation of size
     def to_s(unit = :centimeter)
       converted = to_unit(unit)
-      "#{converted.value} #{converted.unit}"
+      "#{converted.value.to_f} #{converted.unit}"
     end
 
     # Convert all values to one same base unit

--- a/spec/common/classes/ooxml_size_spec.rb
+++ b/spec/common/classes/ooxml_size_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OoxmlParser::OoxmlSize do
+  let(:size) { described_class.new(1, :centimeter) }
+
+  describe '#to_unit' do
+    it 'OoxmlSize to other unit is same to base unit' do
+      expect(size.to_unit('foo')).to eq(size.to_base_unit)
+    end
+
+    it 'OoxmlSize to one_240th_cm' do
+      expect(size.to_unit(:one_240th_cm))
+        .to eq(described_class.new(240, :one_240th_cm))
+    end
+  end
+
+  describe '#to_s' do
+    it 'OoxmlSize to_s output is correct' do
+      expect(size.to_s).to eq('1.0 centimeter')
+    end
+  end
+end


### PR DESCRIPTION
Old variant in test output `1 centimeter` on ruby > 2.4 and
`1.0 centimeter` on ruby = 2.4