### PR TITLE
`RunProperties` can intialize `#font_name` in constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* `RunProperties` can intialize `#font_name` in constructor
+
 ## 0.8.0 (2020-07-31)
 
 ### Fixes

--- a/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_run/run_properties.rb
+++ b/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_run/run_properties.rb
@@ -52,11 +52,12 @@ module OoxmlParser
     # @return [RunStyle] run style
     attr_accessor :run_style
 
-    def initialize(parent: nil)
+    def initialize(params = {})
       @font_name = ''
       @font_style = FontStyle.new
       @baseline = :baseline
-      @parent = parent
+      @parent = params[:parent]
+      @font_name = params[:font_name]
     end
 
     # Parse RunProperties object

--- a/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_run/run_properties.rb
+++ b/lib/ooxml_parser/common_parser/common_data/paragraph/paragraph_run/run_properties.rb
@@ -53,11 +53,10 @@ module OoxmlParser
     attr_accessor :run_style
 
     def initialize(params = {})
-      @font_name = ''
+      @font_name = params.fetch(:font_name, '')
       @font_style = FontStyle.new
       @baseline = :baseline
       @parent = params[:parent]
-      @font_name = params[:font_name]
     end
 
     # Parse RunProperties object

--- a/spec/common/classes/run_properties_spec.rb
+++ b/spec/common/classes/run_properties_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe OoxmlParser::RunProperties do
+  it 'RunProperties can be initialized with specific font name' do
+    font_name = 'Arial'
+    expect(described_class.new(font_name: font_name).font_name).to eq(font_name)
+  end
+end


### PR DESCRIPTION
Fix failure in here
https://github.com/ONLYOFFICE/testing-documentserver/blob/d6859352c12c20c4653c9ab2dd20ea8a9d9d9599/data/models/numbering_level.rb#L16

Since `#font_name` no longer `attr_accessor` since https://github.com/ONLYOFFICE/ooxml_parser/pull/637/files#diff-4291523020689d81f7abcb80030e6d6dR19