### PR TITLE
Fix URI NameError in ruby 3.x

### DIFF
--- a/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/picture/docx_blip/file_reference.rb
+++ b/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/picture/docx_blip/file_reference.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 module OoxmlParser
   # Class for storing image data
   class FileReference < OOXMLDocumentObject
@@ -29,7 +31,7 @@ module OoxmlParser
         return self
       end
       return self if @path == 'NULL'
-      return self if @path.match?(URI::DEFAULT_PARSER.make_regexp)
+      return self if @path.match?(::URI::DEFAULT_PARSER.make_regexp)
 
       full_path_to_file = OOXMLDocumentObject.path_to_folder + OOXMLDocumentObject.root_subfolder + @path.gsub('..', '')
       if File.exist?(full_path_to_file)

--- a/spec/workbook/worksheet/drawing/picture_spec.rb
+++ b/spec/workbook/worksheet/drawing/picture_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'uri'
 
 describe 'My behaviour' do
   it 'ImageSize' do


### PR DESCRIPTION
As of Ruby 3.x, URI is not required per default and URI would be resolved to OoxmlParser::FileReference::URI