### PR TITLE
Fix problem with no `require 'uri'`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Fixes
+
+* Fix problem with no `require 'uri'` (Thanks [@545ch4](https://github.com/545ch4))
+
 ### Changes
 
 * Minor style fixes from `rubocop` v1.19.0

--- a/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/picture/docx_blip/file_reference.rb
+++ b/lib/ooxml_parser/common_parser/common_data/alternate_content/drawing/graphic/picture/docx_blip/file_reference.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 module OoxmlParser
   # Class for storing image data
   class FileReference < OOXMLDocumentObject


### PR DESCRIPTION
Can be reproduced on ruby v3.0 with this script:
```

require 'ooxml_parser'

begin
  presentation = OoxmlParser::Parser.parse(ARGV.first)
rescue Exception => e
  warn "Error while parsing '#{ARGV.first}': #{e.message}\n" << e.backtrace.join("\n")
end
```
with file [uri_name_error.pptx](https://github.com/ONLYOFFICE/ooxml_parser/files/7104127/uri_name_error.pptx)
```
chmod +x script.rb
./script.rb uri_name_error.pptx
```

More details at
https://github.com/ONLYOFFICE/ooxml_parser/pull/824

This problem seems cannot be reproduced via `rspec` or `irb`, only from clean script