### PR TITLE
Actualize `nodejs` version in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,6 +25,8 @@ jobs:
     - name: Check `simplecov` line coverage
       run: cat coverage/.last_run.json | jq '.result.line' | grep -q '100'
     - uses: actions/setup-node@v1
+      with:
+        node-version: '16'
     - name: Check markdown files using `markdownlint`
       run: |
         npm install -g markdownlint-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Drop `ruby-2.5` support since `nokogiri` v1.13.0 dropped it
+* Actualize `nodejs` version in CI
 
 ## 0.22.0 (2022-01-10)
 


### PR DESCRIPTION
By default nodejs-10 is installed and it's
incompatible with latest `markdownlint-cli`