### PR TITLE
Upgrade bundler in Gemfile.lock to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,4 +102,4 @@ DEPENDENCIES
   yard (>= 0.9.20)
 
 BUNDLED WITH
-   2.5.11
+   2.5.12


### PR DESCRIPTION
We don't usually need to specific update, but in current case bundler v2.5.11 have a bug in truffleruby:
https://github.com/rubygems/rubygems/pull/7703
And this cause:
```
/home/runner/.rubies/truffleruby-24.0.1/lib/gems/gems/bundler-2.5.11/lib/bundler/shared_helpers.rb:18:in `const_missing': uninitialized constant Bundler::SharedHelpers::Pathname (NameError)
Did you mean?  Bundler::PathError
```
on our nigtly runs on truffleruby:
https://github.com/ONLYOFFICE/ooxml_parser/actions/runs/9509988930/job/26215753693